### PR TITLE
Allow already replicated records to be removed from pending_changes

### DIFF
--- a/lib/rubyrep/proxy_connection.rb
+++ b/lib/rubyrep/proxy_connection.rb
@@ -382,6 +382,7 @@ module RR
     # +values+ is a hash of column_name => value pairs.
     def insert_record(table, values)
       execute table_insert_query(table, values)
+    rescue ActiveRecord::RecordNotUnique => err
     end
     
     # Returns an SQL update query.

--- a/lib/rubyrep/replicators/one_way_replicator.rb
+++ b/lib/rubyrep/replicators/one_way_replicator.rb
@@ -261,16 +261,7 @@ module RR
       # * +diff+: the current ReplicationDifference instance
       # * +remaining_attempts+: the number of remaining replication attempts for this difference
       def attempt_change(action, source_db, target_db, diff, remaining_attempts)
-        begin
-          rep_helper.session.send(target_db).execute "savepoint rr_#{action}_#{remaining_attempts}"
-          yield
-          unless rep_helper.new_transaction?
-            rep_helper.session.send(target_db).execute "release savepoint rr_#{action}_#{remaining_attempts}"
-          end
-        rescue Exception => e
-          rep_helper.session.send(target_db).execute "rollback to savepoint rr_#{action}_#{remaining_attempts}"
-          raise
-        end
+        yield
       end
 
       # Attempts to delete the source record from the target database.


### PR DESCRIPTION
Remove savepoint setup and teardown.  We're already in a transaction block, this is causing a lot of errors when the connection is reset from under it.
Rescue ActiveRecord::RecordNotUnique errors allowing already replicated records to be removed from the pending_changes table.
Remove old difference loader code that is no longer needed, but still querying the database.

https://bugzilla.redhat.com/show_bug.cgi?id=1119453
