### PR TITLE
Leverage ActiveRecord's transaction block to manage savepoints

### DIFF
--- a/lib/rubyrep/proxy_connection.rb
+++ b/lib/rubyrep/proxy_connection.rb
@@ -111,6 +111,7 @@ module RR
       :quote_table_name, :execute,
       :select_one, :select_all, :tables, :update, :delete,
       :begin_db_transaction, :rollback_db_transaction, :commit_db_transaction,
+      :transaction, :decrement_open_transactions, :increment_open_transactions,
       :referenced_tables,
       :create_or_replace_replication_trigger_function,
       :create_replication_trigger, :drop_replication_trigger, :replication_trigger_exists?,

--- a/lib/rubyrep/replication_helper.rb
+++ b/lib/rubyrep/replication_helper.rb
@@ -50,6 +50,11 @@ module RR
       committer.delete_record(database, table, values)
     end
 
+    # Delegates to Committers::BufferedCommitter#commit
+    def commit
+      committer.commit if committer.respond_to?(:commit)
+    end
+
     # Loads the specified record. Returns an according column_name => value hash.
     # Parameters:
     # * +database+: either :+left+ or :+right+

--- a/lib/rubyrep/replication_run.rb
+++ b/lib/rubyrep/replication_run.rb
@@ -23,8 +23,7 @@ module RR
 
     # Returns the current replicator; creates it if necessary.
     def replicator
-      @replicator ||=
-        Replicators.replicators[session.configuration.options[:replicator]].new(helper)
+      @replicator ||= Replicators.replicators[session.configuration.options[:replicator]].new(helper)
     end
 
     # Returns the current LoggedChangeLoaders; creates it if necessary
@@ -97,7 +96,7 @@ module RR
               break unless diff.loaded?
               break_on_terminate = sweeper.terminated? || $rubyrep_shutdown
               break if break_on_terminate
-              if diff.type != :no_diff and not event_filtered?(diff)
+              if diff.type != :no_diff and not event_filtered?(diff)  # Should probably be :no_change, :no_diff doesn't exist
                 replicator.replicate_difference diff
               end
             rescue Exception => e
@@ -112,8 +111,7 @@ module RR
                 second_chancers << diff
               else
                 begin
-                  helper.log_replication_outcome diff, e.message,
-                    e.class.to_s + "\n" + e.backtrace.join("\n")
+                  helper.log_replication_outcome diff, e.message, e.class.to_s + "\n" + e.backtrace.join("\n")
                 rescue Exception => _
                   # if logging to database itself fails, re-raise the original exception
                   raise e


### PR DESCRIPTION
Fix issue closing and opening new transaction block in BufferedCommitter...
Savepoint was created, command (insert, delete, etc.) was issued (and called "commit")
If the change_counter was at the commit_frequency, the existing transaction would be committed and a new one would be created.
The first command in the new transaction was to release or rollback the previous savepoint which would raise an exception.

https://bugzilla.redhat.com/show_bug.cgi?id=1119453
