### PR TITLE
Implemented a heartbeat in the replication process. 

### DIFF
--- a/lib/rubyrep.rb
+++ b/lib/rubyrep.rb
@@ -71,5 +71,8 @@ Dir["#{File.dirname(__FILE__)}/rubyrep/replication_extenders/*.rb"].each do |ext
 end
 
 module RR
-  
+  def self.heartbeat(file)
+    require 'fileutils'
+    FileUtils.touch(file) unless file.nil?
+  end
 end

--- a/lib/rubyrep/base_runner.rb
+++ b/lib/rubyrep/base_runner.rb
@@ -172,6 +172,8 @@ EOS
           processor.run do |diff_type, row|
             report_printer.report_difference diff_type, row
           end
+
+          RR.heartbeat(options[:heartbeat_file])
         end
       end
       signal_scanning_completion

--- a/lib/rubyrep/replication_initializer.rb
+++ b/lib/rubyrep/replication_initializer.rb
@@ -387,6 +387,9 @@ module RR
         runner.execute
       end
 
+      # Initialize heartbeat file
+      FileUtils.touch(session.configuration.options[:heartbeat_file]) if session.configuration.options[:heartbeat_file]
+
       puts "Starting replication"
     end
   end

--- a/lib/rubyrep/replication_initializer.rb
+++ b/lib/rubyrep/replication_initializer.rb
@@ -379,16 +379,16 @@ module RR
         "#{table_pair[:left]}, #{table_pair[:right]}"
       end
 
+      # Initialize heartbeat file
+      RR.heartbeat(session.configuration.options[:heartbeat_file])
+
       unless session.configuration.options[:no_sync] || unsynced_table_specs.empty?
         puts "Executing initial table syncs"
         runner = SyncRunner.new
         runner.session = session
-        runner.options = {:table_specs => unsynced_table_specs}
+        runner.options = {:table_specs => unsynced_table_specs, :heartbeat_file => session.configuration.options[:heartbeat_file]}
         runner.execute
       end
-
-      # Initialize heartbeat file
-      FileUtils.touch(session.configuration.options[:heartbeat_file]) if session.configuration.options[:heartbeat_file]
 
       puts "Starting replication"
     end

--- a/lib/rubyrep/replication_run.rb
+++ b/lib/rubyrep/replication_run.rb
@@ -64,6 +64,8 @@ module RR
     def run
       $stdout.write "-" if session.configuration.options[:replication_trace]
 
+      heartbeat
+
       return unless [:left, :right].any? do |database|
         next false if session.configuration.send(database)[:mode] == :slave
         changes_pending = false
@@ -150,6 +152,12 @@ module RR
       self.session = session
       self.sweeper = sweeper
       install_sweeper
+    end
+
+    def heartbeat
+      return if session.configuration.options[:heartbeat_file].nil?
+
+      FileUtils.touch(session.configuration.options[:heartbeat_file])
     end
   end
 end

--- a/lib/rubyrep/replication_run.rb
+++ b/lib/rubyrep/replication_run.rb
@@ -64,7 +64,7 @@ module RR
     def run
       $stdout.write "-" if session.configuration.options[:replication_trace]
 
-      heartbeat
+      RR.heartbeat(session.configuration.options[:heartbeat_file])
 
       return unless [:left, :right].any? do |database|
         next false if session.configuration.send(database)[:mode] == :slave
@@ -152,12 +152,6 @@ module RR
       self.session = session
       self.sweeper = sweeper
       install_sweeper
-    end
-
-    def heartbeat
-      return if session.configuration.options[:heartbeat_file].nil?
-
-      FileUtils.touch(session.configuration.options[:heartbeat_file])
     end
   end
 end

--- a/lib/rubyrep/replication_run.rb
+++ b/lib/rubyrep/replication_run.rb
@@ -90,6 +90,8 @@ module RR
 
         loop do
           $stdout.write "." if session.configuration.options[:replication_trace]
+          RR.heartbeat(session.configuration.options[:heartbeat_file])
+
           break unless loaders.update # ensure the cache of change log records is up-to-date
 
           loop do


### PR DESCRIPTION
The heartbeat is done by touching a temporary file (/temp/rubyrep_hb) each time it checks the backlog for work. This enables a parent process that has launched replication to check if the process is actually doing work.

https://bugzilla.redhat.com/show_bug.cgi?id=1127855

https://github.com/ManageIQ/manageiq/pull/3595 depends on this change.
