### PR TITLE
Use the :requires_new option for nested transactions

### DIFF
--- a/lib/rubyrep/replicators/one_way_replicator.rb
+++ b/lib/rubyrep/replicators/one_way_replicator.rb
@@ -261,7 +261,7 @@ module RR
       # * +diff+: the current ReplicationDifference instance
       # * +remaining_attempts+: the number of remaining replication attempts for this difference
       def attempt_change(action, source_db, target_db, diff, remaining_attempts)
-        rep_helper.session.send(target_db).transaction { yield }
+        rep_helper.session.send(target_db).transaction(:requires_new => true) { yield }
         rep_helper.commit
       end
 


### PR DESCRIPTION
Nested transactions are not really supported at the database level.
Because of this, nesting transaction blocks can cause the outer block to be aborted which will cause later SQL statements to fail with the message:

```
PG::InFailedSqlTransaction: ERROR: current transaction is aborted, commands ignored until end of transaction block
```

This is currently the case with the `BufferedCommitter`'s 1000 change transaction and the one started in the attempt_change method in the `OneWayReplicator`.

To deal with this the `PostgreSQLAdapter#transaction` method accepts a `:requires_new` option which uses save points to simulate nested transactions.

This change adds this option to the previously nested transaction in the `OneWayReplicator`

This will allow for the insert to fail (for example with a unique constraint error) and the outer transaction to continue.

More information about this option can be found at:
http://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/DatabaseStatements.html#method-i-transaction

Worked on this with @gtanzillo 

https://bugzilla.redhat.com/show_bug.cgi?id=1348576
