### PR TITLE
Remove the quotes from the trigger variable names OLD and NEW

### DIFF
--- a/lib/rubyrep/replication_extenders/postgresql_replication.rb
+++ b/lib/rubyrep/replication_extenders/postgresql_replication.rb
@@ -17,7 +17,7 @@ module RR
 
       TABLE_PLACEHOLDER = "'table'placeholder'"
       def expand_conditional_clause(cond, relation_name)
-        RR::ProxyConnection.expand_conditional_clause(cond, TABLE_PLACEHOLDER).gsub(TABLE_PLACEHOLDER, relation_name)
+        RR::ProxyConnection.expand_conditional_clause(cond, TABLE_PLACEHOLDER).gsub("\"#{TABLE_PLACEHOLDER}\"", relation_name)
       end
 
       # Returns the filter clause that is used to filter rows from the trigger.


### PR DESCRIPTION
This was a regression introduced in af43a45a68bb6ef153e458b37563a90b3fb3de29

This fixes our issue with the triggers not working for the `reserves` table in manageiq.

@gtanzillo @Fryguy 